### PR TITLE
Add: add volume mounts to db and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Setup
 
 ### Add `.env`
+
 ```
 FRONT_URL=https://taxi.sparcs.org
 BACK_URL=https://taxi.sparcs.org:444
@@ -17,10 +18,23 @@ AWS_SECRET_ACCESS_KEY=
 AWS_S3_BUCKET_NAME=sparcs-taxi-prod
 ```
 
-### Compose up
+### Create named volumes to store persistent MongoDB data & logs, backend logs
+
 ```bash
-$ docker-compose up -d
+$ docker volume create taxi-mongo-logs
+taxi-mongo-logs
+$ docker volume create taxi-mongo-data
+taxi-mongo-data
+$ docker volume create taxi-back-logs
+taxi-back-logs
+```
+
+### Compose up
+
+```bash
+docker-compose up -d
 ```
 
 ### ~~Build Reverse proxy~~
- - ~~See [reverse-proxy/README.md](reverse-proxy/README.md)~~
+
+- ~~See [reverse-proxy/README.md](reverse-proxy/README.md)~~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   taxi-front:
@@ -10,7 +10,7 @@ services:
     environment:
       - REACT_APP_BACK_URL=${BACK_URL}
       - REACT_APP_S3_URL=${S3_URL}
-  
+
   taxi-back:
     container_name: taxi-back
     restart: always
@@ -31,18 +31,29 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_S3_BUCKET_NAME=${AWS_S3_BUCKET_NAME}
-
       - DB_PATH=mongodb://taxi-mongo:27017/taxi
       - REDIS_PATH=redis://taxi-redis:6379
-  
+    volumes:
+      - taxi-back-logs:/usr/src/app:rw
+
   taxi-mongo:
     container_name: taxi-mongo
     restart: always
     image: mongo:4.4
     volumes:
       - ./taxi-mongo/mongodb.conf:/etc/mongodb.conf
-  
+      - taxi-mongo-logs:/var/log/mongodb/mongod.log:rw
+      - taxi-mongo-data:/data/db:rw
+
   taxi-redis:
     container_name: taxi-redis
     restart: always
     image: redis:7.0.4-alpine
+
+volumes:
+  taxi-mongo-logs:
+    external: true
+  taxi-mongo-data:
+    external: true
+  taxi-back-logs:
+    external: true


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #1 
taxi-mongo 컨테이너의 데이터와 로그 디렉토리, taxi-back 컨테이너의 로그 디렉토리를 각각 taxi-mongo-data, taxi-mongo-logs, taxi-back-logs 볼륨에 마운트합니다.
이들 볼륨은 ```docker compose up``` 명령을 실행하기 전에 생성되어 있어야 하며, 그렇지 않은 경우 오류를 반환합니다.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? n

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

- 없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
