### PR TITLE
Socket.io 서버 주소 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 ### Add `.env`
 
-```
+```bash
 FRONT_URL=https://taxi.sparcs.org
 BACK_URL=https://taxi.sparcs.org:444
+SOCKET_IO_URL=https://taxi.sparcs.org:444
 S3_URL=https://sparcs-taxi-prod.s3.ap-northeast-2.amazonaws.com
 FRONT_PORT=80
 BACK_PORT=81

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "${FRONT_PORT}:80"
     environment:
       - REACT_APP_BACK_URL=${BACK_URL}
+      - REACT_APP_IO_URL=${SOCKET_IO_URL}
       - REACT_APP_S3_URL=${S3_URL}
 
   taxi-back:


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #3 

https://github.com/sparcs-kaist/taxi-front/issues/178 이슈를 해결하기 위해 프론트엔드에서 Express 서버와 Socket.io 서버의 주소를 서로 다른 변수로 분리했습니다. 이에 따라 taxi-docker에서 설정할 수 있는 환경 변수도 분리하여 설정할 수 있게 수정하였습니다.
SOCKET_IO_URL 환경변수에 아무 값을 넣지 않으면 클라이언트에서는 BACK_URL 환경변수와 동일한 주소로 소켓 연결을 시도합니다.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? n

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
