### PR TITLE
Fix: Fix docker volume mount target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - DB_PATH=mongodb://taxi-mongo:27017/taxi
       - REDIS_PATH=redis://taxi-redis:6379
     volumes:
-      - taxi-back-logs:/usr/src/app:rw
+      - taxi-back-logs:/usr/src/app/logs:rw
 
   taxi-mongo:
     container_name: taxi-mongo


### PR DESCRIPTION
It fixes #7
taxi-back-logs 볼륨이 /usr/src/app 전체에 마운트되어 백엔드 코드의 변경사항이 반영되지 않는 문제를 해결합니다.